### PR TITLE
fix: 입고확인 API 연동 및 LocalStorage로 관리하던 것 삭제

### DIFF
--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,7 +1,6 @@
 export default class LocalStorageUtil {
   #sendCompletePurchase = 'brewnet:purchase:send-completed'; // purchase code를 배열 형태로 저장
   #loginId = 'brewnet:auth:saved-id';
-  #completeInStock = 'brewnet:purchase:complete-in-stock'; // 입고 확인된 발주 목록 (purchaseCode, itemCode값 쌍으로 저장)
 
   //
   // 회계부서로 구매품의서 전송
@@ -29,40 +28,6 @@ export default class LocalStorageUtil {
   isSendCompletePurchase(purchaseCode) {
     const foundItems = this.#getSendCompletePurchase();
     return foundItems.includes(purchaseCode);
-  }
-
-  //
-  // 입고 확인 완료된 발주 건
-  //
-
-  #getCompleteInStock() {
-    const foundItems = localStorage.getItem(this.#completeInStock);
-    if (foundItems) return JSON.parse(foundItems);
-    return [];
-  }
-
-  #makeInStockPair(purchaseCode, itemCode) {
-    return `purchase${purchaseCode}:item${itemCode}`;
-  }
-
-  // 입고 처리 진행
-  saveCompleteInStock(purchaseCode, itemCode) {
-    let saveValue = [this.#makeInStockPair(purchaseCode, itemCode)];
-    const foundItems = this.#getCompleteInStock();
-
-    if (foundItems.length > 0) {
-      // 기존에 이미 저장된게 있다면 가져오기
-      saveValue = saveValue.concat(foundItems);
-    }
-
-    localStorage.setItem(this.#completeInStock, JSON.stringify(saveValue));
-  }
-
-  // 입고 이미 처리된 발주건인지?
-  isCompleteInStock(purchaseCode, itemCode) {
-    const pair = this.#makeInStockPair(purchaseCode, itemCode);
-    const foundItems = this.#getCompleteInStock();
-    return foundItems.includes(pair);
   }
 
   //

--- a/src/views/headQuarter/PurchaseStockArrivalListView.vue
+++ b/src/views/headQuarter/PurchaseStockArrivalListView.vue
@@ -47,7 +47,6 @@ import HQPurchaseApi from '@/utils/api/HQPurchaseApi';
 import { CRITERIA_IN_STOCK, SEARCH_CRITERIA } from '@/utils/constant';
 import { formatKoSearchCriteria } from '@/utils/format';
 import { makeSelectOption, makeTabs } from '@/utils/helper';
-import LocalStorageUtil from '@/utils/localStorage';
 
 const { showConfirm } = useAppConfirmModal();
 const toast = useToast();
@@ -73,22 +72,19 @@ function formatKoTabItem(tabValue) {
   if (tabValue === TAB_ITEM.UNCHECK) return '미확인 입고내역';
   return 'Tab';
 }
-const activeTab = ref(TAB_ITEM.ALL);
+const activeTab = ref(TAB_ITEM.UNCHECK);
 
 const criteriaOptions = computed(() => {
   return CRITERIA_IN_STOCK.map(e => makeSelectOption(formatKoSearchCriteria(e), e));
 });
 const tabItems = computed(() => {
-  return [TAB_ITEM.ALL, TAB_ITEM.UNCHECK].map(e => makeTabs(formatKoTabItem(e), e));
+  return [TAB_ITEM.UNCHECK, TAB_ITEM.ALL].map(e => makeTabs(formatKoTabItem(e), e));
 });
 
 const hqPurchaseApi = new HQPurchaseApi();
-const localStorageUtil = new LocalStorageUtil();
 
 const onStockUncheckToCheck = data => {
   hqPurchaseApi.stockIn({ itemCode: data.itemCode, purchaseCode: data.purchaseCode }).then(() => {
-    localStorageUtil.saveCompleteInStock(data.purchaseCode, data.itemCode);
-
     toast.add({ severity: 'success', summary: '처리 성공', detail: '입고처리되었습니다.', life: 3000 });
     onReload();
   });
@@ -126,15 +122,15 @@ const columns = [
       button: [
         {
           getLabel: data => {
-            if (localStorageUtil.isCompleteInStock(data.purchaseCode, data.itemCode)) {
+            if (data.storageConfirmed) {
               return '입고완료';
             }
             return '입고확인';
           },
           clickHandler: handleStockIn,
-          getDisabled: data => localStorageUtil.isCompleteInStock(data.purchaseCode, data.itemCode),
+          getDisabled: data => data.storageConfirmed,
           getSeverity: data => {
-            if (localStorageUtil.isCompleteInStock(data.purchaseCode, data.itemCode)) return 'secondary';
+            if (data.storageConfirmed) return 'secondary';
             return undefined;
           },
         },


### PR DESCRIPTION
### 요약
- 입고확인 API 연동 및 LocalStorage로 관리하던 로직 삭제

### 관련 이슈
- #44
