### PR TITLE
[PURCHASE] 구매품의서 삭제(결재 요청 취소) api 연동

### DIFF
--- a/src/utils/api/HQPurchaseApi.js
+++ b/src/utils/api/HQPurchaseApi.js
@@ -134,4 +134,15 @@ export default class HQPurchaseApi extends BaseApiService {
       comment,
     });
   }
+
+  //
+  // DELETE
+  //
+
+  // 발주(구매품의서) 결재 요청 취소
+  deletePurchase(purchaseCode) {
+    return this.delete('/cancel', {
+      letterOfPurchaseCode: purchaseCode,
+    });
+  }
 }

--- a/src/views/headQuarter/PurchaseDetailView.vue
+++ b/src/views/headQuarter/PurchaseDetailView.vue
@@ -33,6 +33,7 @@
           />
           <Button label="목록으로" size="small" severity="secondary" variant="outlined" @click="clickGoToList" />
           <Button
+            v-if="canDelete"
             label="삭제"
             severity="danger"
             size="small"
@@ -115,6 +116,7 @@ import AppTableStyled from '@/components/common/AppTableStyled.vue';
 import DraftApprovalHistoryTable from '@/components/headQuarter/DraftApprovalHistoryTable.vue';
 import DraftApprovalLine from '@/components/headQuarter/DraftApprovalLine.vue';
 import { useAppConfirmModal } from '@/hooks/useAppConfirmModal';
+import { useUserStore } from '@/stores/user';
 import HQPurchaseApi from '@/utils/api/HQPurchaseApi';
 import { APPROVAL_STATUS, DRAFT_KIND } from '@/utils/constant';
 import { formatKoApprovalStatus } from '@/utils/format';
@@ -125,6 +127,7 @@ const route = useRoute();
 const router = useRouter();
 const { showConfirm } = useAppConfirmModal();
 const toast = useToast();
+const userStore = useUserStore();
 
 const purchaseDetail = ref(null);
 const purchaseApprovalLines = ref([]);
@@ -166,17 +169,21 @@ const clickGoToList = () => {
   router.replace({ name: 'hq:purchase:list' });
 };
 
-const deletePurchase = () => {
-  // TODO:: 발주 삭제 API
+const canDelete = computed(() => {
+  return userStore.username === purchaseDetail.value.memberName;
+});
 
-  toast.add({ severity: 'error', summary: '처리 성공', detail: '발주(구매품의서)가 삭제되었습니다.', life: 3000 });
-  router.replace({ name: 'hq:purchase:list' });
+const deletePurchase = () => {
+  hqPurchaseApi.deletePurchase(purchaseCode).then(() => {
+    toast.add({ severity: 'error', summary: '처리 성공', detail: '구매품의서가 삭제되었습니다.', life: 3000 });
+    router.replace({ name: 'hq:purchase:list' });
+  });
 };
 
 const clickDelete = () => {
   showConfirm({
     header: '발주 삭제',
-    message: '발주(구매품의서)를 삭제하시겠습니까?',
+    message: '구매품의서를 삭제하시겠습니까?',
     acceptLabel: '발주 삭제',
     onAccept: deletePurchase,
     danger: true,


### PR DESCRIPTION
### 요약
- 구매품의서 삭제(결재 요청 취소) api 연동

### 관련 이슈
-  

### 완료 사항
- 구매품의서 삭제(결재 요청 취소) api 연동 완료
- 상세 페이지에서 구매품의서 작성자 본인이 아니라면 삭제 버튼이 안 보이도록 처리

### 필요 테스트
- 완료한 기능에 대한 테스트 케이스

### 스크린샷 (선택사항)
- 사진을 업로드해주세요

### 체크리스트
- [ ] 닌자코드로 작성하지 않았나요?
- [ ] 작성 코드에 대한 셀프체크를 하셨나요?
- [ ] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [ ] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [ ] 테스트코드가 모두 잘 작동하나요?
