### PR TITLE
[STORAGE] 창고별 상품 재고 조정 api 연동

### DIFF
--- a/src/components/headQuarter/ChangeStockModalBody.vue
+++ b/src/components/headQuarter/ChangeStockModalBody.vue
@@ -1,0 +1,55 @@
+<template>
+  <AppModalBody action-button-label="저장" @click-action-button="clickSave">
+    <AppInputText v-model="quantity" label="조정 수량" label-position="left" full-width placeholder="숫자만 입력" />
+  </AppModalBody>
+</template>
+
+<script setup>
+import { useToast } from 'primevue';
+import { computed, onMounted, inject, ref } from 'vue';
+
+import HQStorageApi from '@/utils/api/HQStorageApi';
+
+import AppModalBody from '../common/AppModalBody.vue';
+import AppInputText from '../common/form/AppInputText.vue';
+
+const toast = useToast();
+const hqStorageApi = new HQStorageApi();
+
+const dialogRef = inject('dialogRef');
+const selectedStorage = ref(null);
+const selectedItem = ref(null);
+const quantity = ref(null);
+
+const checkForm = () => {
+  try {
+    if (!quantity.value) throw new Error('재고에 합산할 수량을 입력해주세요.');
+
+    return true;
+  } catch (e) {
+    toast.add({ severity: 'error', summary: '입력 확인', detail: e.message, life: 3000 });
+    return false;
+  }
+};
+
+const clickSave = () => {
+  const isPass = checkForm();
+  if (!isPass) return;
+
+  hqStorageApi
+    .changeStock({ storageCode: selectedStorage.value, itemCode: selectedItem.value, quantity: quantity.value })
+    .then(() => {
+      dialogRef.value.close({
+        reload: true,
+      });
+    });
+};
+
+onMounted(() => {
+  const { storageCode, itemCode } = dialogRef.value.data;
+  selectedStorage.value = storageCode;
+  selectedItem.value = itemCode;
+});
+</script>
+
+<style scoped></style>

--- a/src/utils/api/HQStorageApi.js
+++ b/src/utils/api/HQStorageApi.js
@@ -89,6 +89,15 @@ export default class HQStorageApi extends BaseApiService {
     });
   }
 
+  // 창고별 상품 재고 조정
+  changeStock({ storageCode, itemCode, quantity }) {
+    return this.put('/change-stock', {
+      storageCode,
+      itemCode,
+      quantity,
+    });
+  }
+
   //
   // DELETE
   //

--- a/src/views/headQuarter/StockListByStorageView.vue
+++ b/src/views/headQuarter/StockListByStorageView.vue
@@ -22,24 +22,28 @@
       @change-page="onChangePage"
       @export-excel="onExportExcel"
     />
+
+    <DynamicDialog />
   </div>
 </template>
 
 <script setup>
 import dayjs from 'dayjs';
 import { useToast } from 'primevue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, defineAsyncComponent, onMounted, ref } from 'vue';
 
 import AppTable from '@/components/common/AppTable.vue';
 import AppInputText from '@/components/common/form/AppInputText.vue';
 import AppSelect from '@/components/common/form/AppSelect.vue';
 import SearchArea from '@/components/common/SearchArea.vue';
+import { useModal } from '@/hooks/useModal';
 import HQStorageApi from '@/utils/api/HQStorageApi';
 import { SEARCH_CRITERIA } from '@/utils/constant';
 import ExcelManager from '@/utils/ExcelManager';
 import { makeSelectOption } from '@/utils/helper';
 
 const toast = useToast();
+const { openModal } = useModal();
 
 const page = ref(1);
 const pageSize = ref(15);
@@ -56,6 +60,27 @@ const getInitialCriteria = () => ({
   keyword: '',
 });
 const criteria = ref(getInitialCriteria());
+
+const ChangeStockModalBody = defineAsyncComponent(() => import('@/components/headQuarter/ChangeStockModalBody.vue'));
+
+function changeStock(data) {
+  openModal({
+    component: ChangeStockModalBody,
+    header: '재고 조정',
+    data: {
+      storageCode: data.storageCode,
+      itemCode: data.itemCode,
+    },
+    onClose: opt => {
+      const callbackParams = opt.data;
+      if (!callbackParams) return;
+
+      if (callbackParams.reload) {
+        getStockList();
+      }
+    },
+  });
+}
 
 const columns = [
   { field: 'itemUniqueCode', header: '품목코드', sortable: true },
@@ -84,6 +109,18 @@ const columns = [
     header: '현재재고',
     render: data => data.currentStock.toLocaleString(),
     alignment: 'right',
+  },
+  {
+    field: '',
+    header: '',
+    template: {
+      button: [
+        {
+          getLabel: () => '재고조정',
+          clickHandler: changeStock,
+        },
+      ],
+    },
   },
 ];
 


### PR DESCRIPTION
### 요약
- 창고별 상품 재고 조정 api 연동

### 관련 이슈
- 

### 완료 사항
- 창고별 상품 재고 조정 api 연동 완료
- '재고 조정' 버튼 클릭 시 뜨는 모달창 생성

### 필요 테스트
- 완료한 기능에 대한 테스트 케이스

### 스크린샷 (선택사항)
- 사진을 업로드해주세요

### 체크리스트
- [ ] 닌자코드로 작성하지 않았나요?
- [ ] 작성 코드에 대한 셀프체크를 하셨나요?
- [ ] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [ ] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [ ] 테스트코드가 모두 잘 작동하나요?
